### PR TITLE
fix(expandWithMerge): should respect falsy values

### DIFF
--- a/src/__tests__/__snapshots__/expandWithMerge-test.js.snap
+++ b/src/__tests__/__snapshots__/expandWithMerge-test.js.snap
@@ -48,3 +48,12 @@ Object {
   "paddingTop": "20px",
 }
 `;
+
+exports[`Expanding (with merge) style objects should expand and merge properties with non-undefined values 1`] = `
+Object {
+  "paddingBottom": 0,
+  "paddingLeft": null,
+  "paddingRight": undefined,
+  "paddingTop": "20px",
+}
+`;

--- a/src/__tests__/expandWithMerge-test.js
+++ b/src/__tests__/expandWithMerge-test.js
@@ -14,6 +14,17 @@ describe('Expanding (with merge) style objects', () => {
     ).toMatchSnapshot()
   })
 
+  it('should expand and merge properties with non-undefined values', () => {
+    expect(
+      expandWithMerge({
+        padding: '20px 10px',
+        paddingBottom: 0,
+        paddingLeft: null,
+        paddingRight: undefined,
+      })
+    ).toMatchSnapshot()
+  })
+
   it('should expand and merge border properties in nested objects', () => {
     expect(
       expandWithMerge({

--- a/src/expandWithMerge.js
+++ b/src/expandWithMerge.js
@@ -2,7 +2,7 @@ import expandProperty from './expandProperty'
 
 function mergeBase(longhands, base) {
   for (const property in longhands) {
-    if (base[property]) {
+    if (base.hasOwnProperty(property)) {
       longhands[property] = base[property]
     }
   }
@@ -41,6 +41,8 @@ export default function expandWithMerge(style) {
         Object.assign(style, mergeBase(expansion, style))
         delete style[property]
       }
+    } else if (value === null) {
+      // should skip
     } else if (typeof value === 'object' && !Array.isArray(value)) {
       expandWithMerge(value)
     }


### PR DESCRIPTION
### 💥 Issue

I tried to use it with Fela plugin (https://github.com/stardust-ui/react/pull/1925) and meet and issue with handling falsy values like `null`, `undefined`, `0`.

The simplest repro is below:

```js
expandWithMerge({
  padding: '20px',
  paddingBottom: 0,
})
// {
//    paddingBottom: '20px', // <-- should be `0`
//    paddingTop: '20px',
//    paddingLeft: '20px',
//    paddingRight: '20px',
// }
```

We also quite often use `undefined` to clean up existing values.