### PR TITLE
fix: properly merge arrays

### DIFF
--- a/src/__tests__/__snapshots__/expand-test.js.snap
+++ b/src/__tests__/__snapshots__/expand-test.js.snap
@@ -48,10 +48,38 @@ Object {
       "marginRight": "0",
       "marginTop": "0",
     },
+    Object {
+      "outlineColor": Array [
+        "red",
+      ],
+      "outlineStyle": Array [
+        "solid",
+      ],
+      "outlineWidth": Array [
+        "0",
+        "10px",
+      ],
+    },
   ],
   "numeralArray": Array [
     1,
     2,
+  ],
+  "paddingBottom": Array [
+    "1",
+    "20px",
+  ],
+  "paddingLeft": Array [
+    "1",
+    "20px",
+  ],
+  "paddingRight": Array [
+    "1",
+    "20px",
+  ],
+  "paddingTop": Array [
+    "1",
+    "20px",
   ],
 }
 `;

--- a/src/__tests__/__snapshots__/expand-test.js.snap
+++ b/src/__tests__/__snapshots__/expand-test.js.snap
@@ -55,3 +55,10 @@ Object {
   ],
 }
 `;
+
+exports[`Expanding style objects should not throw on undefined values 1`] = `
+Object {
+  "border": undefined,
+  "padding": null,
+}
+`;

--- a/src/__tests__/__snapshots__/expandWithMerge-test.js.snap
+++ b/src/__tests__/__snapshots__/expandWithMerge-test.js.snap
@@ -49,6 +49,15 @@ Object {
 }
 `;
 
+exports[`Expanding (with merge) style objects should expand and merge properties with non-undefined values 1`] = `
+Object {
+  "paddingBottom": 0,
+  "paddingLeft": null,
+  "paddingRight": undefined,
+  "paddingTop": "20px",
+}
+`;
+
 exports[`Expanding (with merge) style objects should expand values in arrays 1`] = `
 Object {
   "extend": Array [
@@ -64,19 +73,36 @@ Object {
       "marginRight": "0",
       "marginTop": "0",
     },
+    Object {
+      "outlineColor": "green",
+      "outlineStyle": Array [
+        "solid",
+      ],
+      "outlineWidth": Array [
+        "0",
+        "10px",
+      ],
+    },
   ],
   "numeralArray": Array [
     1,
     2,
   ],
-}
-`;
-
-exports[`Expanding (with merge) style objects should expand and merge properties with non-undefined values 1`] = `
-Object {
-  "paddingBottom": 0,
-  "paddingLeft": null,
-  "paddingRight": undefined,
-  "paddingTop": "20px",
+  "paddingBottom": Array [
+    "1",
+    "20px",
+  ],
+  "paddingLeft": Array [
+    "1",
+    "20px",
+  ],
+  "paddingRight": Array [
+    "1",
+    "20px",
+  ],
+  "paddingTop": Array [
+    "1",
+    "20px",
+  ],
 }
 `;

--- a/src/__tests__/expand-test.js
+++ b/src/__tests__/expand-test.js
@@ -16,17 +16,24 @@ describe('Expanding style objects', () => {
     ).toMatchSnapshot()
   })
 
+  it('should not throw on undefined values', () => {
+    expect(
+      expand({
+        border: undefined,
+        padding: null,
+      })
+    ).toMatchSnapshot()
+  })
+
   it('should expand values in arrays', () => {
     expect(
       expand({
         numeralArray: [1, 2],
+        padding: [1, '20px'],
         extend: [
-          {
-            padding: '10px',
-          },
-          {
-            margin: 0,
-          },
+          { padding: '10px' },
+          { margin: 0 },
+          { outline: [0, '10px solid red'] },
         ],
       })
     ).toMatchSnapshot()

--- a/src/__tests__/expandWithMerge-test.js
+++ b/src/__tests__/expandWithMerge-test.js
@@ -14,22 +14,20 @@ describe('Expanding (with merge) style objects', () => {
     ).toMatchSnapshot()
   })
 
-
   it('should expand values in arrays', () => {
     expect(
       expandWithMerge({
         numeralArray: [1, 2],
+        padding: [1, '20px'],
         extend: [
-          {
-            padding: '10px',
-          },
-          {
-            margin: 0,
-          },
+          { padding: '10px' },
+          { margin: 0 },
+          { outline: [0, '10px solid red'], outlineColor: 'green' },
         ],
       })
     ).toMatchSnapshot()
-    
+  })
+
   it('should expand and merge properties with non-undefined values', () => {
     expect(
       expandWithMerge({

--- a/src/expand.js
+++ b/src/expand.js
@@ -11,12 +11,21 @@ export default function expand(style) {
         Object.assign(style, expansion)
         delete style[property]
       }
-    } else if (typeof value === 'object') {
-      if (Array.isArray(value)) {
+    } else if (value === null) {
+      // should skip
+    } else if (Array.isArray(value)) {
+      if (property === 'extend') {
         value.map(expand)
       } else {
-        expand(value)
+        const expansion = expandProperty(property, value)
+
+        if (expansion) {
+          Object.assign(style, expansion)
+          delete style[property]
+        }
       }
+    } else if (typeof value === 'object') {
+      expand(value)
     }
   }
 

--- a/src/expandProperty.js
+++ b/src/expandProperty.js
@@ -105,7 +105,7 @@ function parseFlex(value) {
   return longhands
 }
 
-export default function expandProperty(property, value) {
+function expandProperty(property, value) {
   // special expansion for the border property as its 2 levels deep
   if (property === 'border') {
     const longhands = parseBorder(value.toString(), key => 'border' + key)
@@ -129,4 +129,29 @@ export default function expandProperty(property, value) {
   if (borderExpand[property]) {
     return parseBorder(value.toString(), borderExpand[property])
   }
+}
+
+export default function preExpand(property, value) {
+  if (Array.isArray(value)) {
+    const result = {}
+
+    value.forEach(item => {
+      const itemResult = expandProperty(property, item)
+
+      if (itemResult) {
+        Object.keys(itemResult).forEach(itemProperty => {
+          result[itemProperty] = result[itemProperty] || []
+          result[itemProperty].push(itemResult[itemProperty])
+        })
+      }
+    })
+
+    if (Object.keys(result).length) {
+      return result
+    }
+
+    return null
+  }
+
+  return expandProperty(property, value)
 }

--- a/src/expandWithMerge.js
+++ b/src/expandWithMerge.js
@@ -43,12 +43,19 @@ export default function expandWithMerge(style) {
       }
     } else if (value === null) {
       // should skip
-    } else if (typeof value === 'object') {
-      if (Array.isArray(value)) {
+    } else if (Array.isArray(value)) {
+      if (property === 'extend') {
         value.map(expandWithMerge)
       } else {
-        expandWithMerge(value)
+        const expansion = expandProperty(property, value)
+
+        if (expansion) {
+          Object.assign(style, mergeBase(expansion, style))
+          delete style[property]
+        }
       }
+    } else if (typeof value === 'object') {
+      expandWithMerge(value)
     }
   }
 


### PR DESCRIPTION
This PR fixes the issue that was originally reported in Fela: robinweser/fela#735.

```
const style = { border: ["1px solid red", "1px solid invalid"] }
console.log(expand(style))
```

### Before

```
{
  "border": [
    "1px solid red",
    "1px solid invalid"
  ]
} 
```

### After
```
{ 
  borderColor: ["red", "invalid"],
  borderStyle: ["solid", "solid"],
  bordeWidthr: ["1px", "1px"]
}
```