### PR TITLE
Feat: bring expand gap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This also comes with some downsides: We make a lot of consumptions about the CSS
 - flex
 - textDecoration
 - overflow
+- gap
 
 > Need more? Feel free to [create an issue](https://github.com/rofrischmann/inline-style-expand-shorthand/issues/new) with a proposal!
 

--- a/src/__tests__/__snapshots__/expandProperty-test.js.snap
+++ b/src/__tests__/__snapshots__/expandProperty-test.js.snap
@@ -384,6 +384,34 @@ Object {
 }
 `;
 
+exports[`Expanding property values should expand gap correctly 1`] = `
+Object {
+  "columnGap": "20px",
+  "rowGap": "20px",
+}
+`;
+
+exports[`Expanding property values should expand gap correctly 2`] = `
+Object {
+  "columnGap": "50%",
+  "rowGap": "50%",
+}
+`;
+
+exports[`Expanding property values should expand gap correctly 3`] = `
+Object {
+  "columnGap": "10px",
+  "rowGap": "20px",
+}
+`;
+
+exports[`Expanding property values should expand gap correctly 4`] = `
+Object {
+  "columnGap": "unset",
+  "rowGap": "unset",
+}
+`;
+
 exports[`Expanding property values should expand overflow correctly 1`] = `
 Object {
   "overflowX": "visible",

--- a/src/__tests__/expandProperty-test.js
+++ b/src/__tests__/expandProperty-test.js
@@ -130,4 +130,11 @@ describe('Expanding property values', () => {
     expect(expandProperty('overflow', 'visible')).toMatchSnapshot()
     expect(expandProperty('overflow', 'scroll hidden')).toMatchSnapshot()
   })
+
+  it('should expand gap correctly', () => {
+    expect(expandProperty('gap', '20px')).toMatchSnapshot()
+    expect(expandProperty('gap', '50%')).toMatchSnapshot()
+    expect(expandProperty('gap', '20px 10px')).toMatchSnapshot()
+    expect(expandProperty('gap', 'unset')).toMatchSnapshot()
+  })
 })

--- a/src/expandProperty.js
+++ b/src/expandProperty.js
@@ -234,6 +234,16 @@ function parseOverflow(value) {
   return { overflowX: values[0], overflowY: values[1] }
 }
 
+function parseGap(value) {
+  // https://w3c.github.io/csswg-drafts/css-align/#gap-shorthand
+  const [rowGap, columnGap = rowGap] = splitShorthand(value)
+  // This property is a shorthand that sets row-gap and column-gap in one declaration. If <'column-gap'> is omitted, it’s set to the same value as <'row-gap'>.
+  return {
+    rowGap,
+    columnGap
+  }
+}
+
 function expandProperty(property, value) {
   // special expansion for the border property as its 2 levels deep
   if (property === 'border') {
@@ -262,6 +272,10 @@ function expandProperty(property, value) {
   
   if (property === 'overflow') {
     return parseOverflow(value.toString())
+  }
+
+  if (property === 'gap') {
+    return parseGap(value.toString())
   }
 
   if (circularExpand[property]) {


### PR DESCRIPTION
The PR adds support for expanding `gap` into `columnGap` and `rowGap`, per [CSS Box Align Spec](https://w3c.github.io/csswg-drafts/css-align/#gap-shorthand).

The unit test case is also added.