### PR TITLE
Feat: add support for more properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,13 @@ This also comes with some downsides: We make a lot of consumptions about the CSS
 - margin
 - outline
 - flex
+- flexFlow
 - textDecoration
 - overflow
 - gap
+- placeContent
+- placeItems
+- placeSelf
 
 > Need more? Feel free to [create an issue](https://github.com/rofrischmann/inline-style-expand-shorthand/issues/new) with a proposal!
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ This also comes with some downsides: We make a lot of consumptions about the CSS
 - borderColor
 - borderRadius
 - padding
-- padding-inline
-- padding-block
+- paddingInline
+- paddingBlock
 - margin
-- margin-inline
-- margin-block
+- marginInline
+- marginBlock
 - outline
 - flex
 - flexFlow
@@ -52,6 +52,8 @@ This also comes with some downsides: We make a lot of consumptions about the CSS
 - placeSelf
 - transition
 - inset
+- scroll-margin
+- scroll-padding
 
 > Need more? Feel free to [create an issue](https://github.com/rofrischmann/inline-style-expand-shorthand/issues/new) with a proposal!
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ This also comes with some downsides: We make a lot of consumptions about the CSS
 - borderColor
 - borderRadius
 - padding
+- padding-inline
+- padding-block
 - margin
+- margin-inline
+- margin-block
 - outline
 - flex
 - flexFlow

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This also comes with some downsides: We make a lot of consumptions about the CSS
 - placeContent
 - placeItems
 - placeSelf
+- transition
 
 > Need more? Feel free to [create an issue](https://github.com/rofrischmann/inline-style-expand-shorthand/issues/new) with a proposal!
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This also comes with some downsides: We make a lot of consumptions about the CSS
 - placeItems
 - placeSelf
 - transition
+- inset
 
 > Need more? Feel free to [create an issue](https://github.com/rofrischmann/inline-style-expand-shorthand/issues/new) with a proposal!
 

--- a/src/__tests__/__snapshots__/expandProperty-test.js.snap
+++ b/src/__tests__/__snapshots__/expandProperty-test.js.snap
@@ -384,6 +384,44 @@ Object {
 }
 `;
 
+exports[`Expanding property values should expand flexFlow correctly 1`] = `
+Object {
+  "flexDirection": "column",
+  "flexWrap": "nowrap",
+}
+`;
+
+exports[`Expanding property values should expand flexFlow correctly 2`] = `
+Object {
+  "flexDirection": "row",
+  "flexWrap": "wrap",
+}
+`;
+
+exports[`Expanding property values should expand flexFlow correctly 3`] = `
+Object {
+  "flexDirection": "row",
+  "flexWrap": "wrap",
+}
+`;
+
+exports[`Expanding property values should expand flexFlow correctly 4`] = `
+Object {
+  "flexDirection": "row",
+  "flexWrap": "wrap",
+}
+`;
+
+exports[`Expanding property values should expand flexFlow correctly 5`] = `Object {}`;
+
+exports[`Expanding property values should expand flexFlow correctly 6`] = `Object {}`;
+
+exports[`Expanding property values should expand flexFlow correctly 7`] = `Object {}`;
+
+exports[`Expanding property values should expand flexFlow correctly 8`] = `Object {}`;
+
+exports[`Expanding property values should expand flexFlow correctly 9`] = `Object {}`;
+
 exports[`Expanding property values should expand gap correctly 1`] = `
 Object {
   "columnGap": "20px",

--- a/src/__tests__/__snapshots__/expandProperty-test.js.snap
+++ b/src/__tests__/__snapshots__/expandProperty-test.js.snap
@@ -586,6 +586,20 @@ Object {
 
 exports[`Expanding property values should expand placeContent correctly 4`] = `Object {}`;
 
+exports[`Expanding property values should expand placeItems correctly 1`] = `
+Object {
+  "alignItems": "center",
+  "justifyItems": "center",
+}
+`;
+
+exports[`Expanding property values should expand placeItems correctly 2`] = `
+Object {
+  "alignItems": "auto",
+  "justifyItems": "center",
+}
+`;
+
 exports[`Expanding property values should expand text-decoration correctly 1`] = `
 Object {
   "textDecorationLine": "none",

--- a/src/__tests__/__snapshots__/expandProperty-test.js.snap
+++ b/src/__tests__/__snapshots__/expandProperty-test.js.snap
@@ -634,8 +634,34 @@ Object {
 
 exports[`Expanding property values should expand text-decoration correctly 4`] = `
 Object {
-  "textDecorationColor": "underline",
-  "textDecorationLine": "navy",
+  "textDecorationColor": "navy",
+  "textDecorationLine": "underline",
   "textDecorationStyle": "dotted",
 }
 `;
+
+exports[`Expanding property values should expand text-decoration correctly 5`] = `
+Object {
+  "textDecorationColor": "currentColor",
+  "textDecorationLine": "overline underline",
+  "textDecorationStyle": "solid",
+}
+`;
+
+exports[`Expanding property values should expand text-decoration correctly 6`] = `
+Object {
+  "textDecorationColor": "red",
+  "textDecorationLine": "underline",
+  "textDecorationStyle": "solid",
+}
+`;
+
+exports[`Expanding property values should expand text-decoration correctly 7`] = `
+Object {
+  "textDecorationColor": "red",
+  "textDecorationLine": "underline",
+  "textDecorationStyle": "wavy",
+}
+`;
+
+exports[`Expanding property values should expand text-decoration correctly 8`] = `Object {}`;

--- a/src/__tests__/__snapshots__/expandProperty-test.js.snap
+++ b/src/__tests__/__snapshots__/expandProperty-test.js.snap
@@ -563,6 +563,29 @@ Object {
 }
 `;
 
+exports[`Expanding property values should expand placeContent correctly 1`] = `
+Object {
+  "alignContent": "center",
+  "justifyContent": "center",
+}
+`;
+
+exports[`Expanding property values should expand placeContent correctly 2`] = `
+Object {
+  "alignContent": "center",
+  "justifyContent": "start",
+}
+`;
+
+exports[`Expanding property values should expand placeContent correctly 3`] = `
+Object {
+  "alignContent": "baseline",
+  "justifyContent": "start",
+}
+`;
+
+exports[`Expanding property values should expand placeContent correctly 4`] = `Object {}`;
+
 exports[`Expanding property values should expand text-decoration correctly 1`] = `
 Object {
   "textDecorationLine": "none",

--- a/src/__tests__/__snapshots__/expandProperty-test.js.snap
+++ b/src/__tests__/__snapshots__/expandProperty-test.js.snap
@@ -450,6 +450,42 @@ Object {
 }
 `;
 
+exports[`Expanding property values should expand inset correctly 1`] = `
+Object {
+  "bottom": "12px",
+  "left": "12px",
+  "right": "12px",
+  "top": "12px",
+}
+`;
+
+exports[`Expanding property values should expand inset correctly 2`] = `
+Object {
+  "bottom": "12px",
+  "left": "24px",
+  "right": "24px",
+  "top": "12px",
+}
+`;
+
+exports[`Expanding property values should expand inset correctly 3`] = `
+Object {
+  "bottom": "48px",
+  "left": "24px",
+  "right": "24px",
+  "top": "12px",
+}
+`;
+
+exports[`Expanding property values should expand inset correctly 4`] = `
+Object {
+  "bottom": "48px",
+  "left": "72px",
+  "right": "24px",
+  "top": "12px",
+}
+`;
+
 exports[`Expanding property values should expand overflow correctly 1`] = `
 Object {
   "overflowX": "visible",

--- a/src/__tests__/__snapshots__/expandProperty-test.js.snap
+++ b/src/__tests__/__snapshots__/expandProperty-test.js.snap
@@ -665,3 +665,48 @@ Object {
 `;
 
 exports[`Expanding property values should expand text-decoration correctly 8`] = `Object {}`;
+
+exports[`Expanding property values should expand transition correctly 1`] = `
+Object {
+  "transitionDelay": "initial",
+  "transitionDuration": "initial",
+  "transitionProperty": "initial",
+  "transitionTimingFunction": "initial",
+}
+`;
+
+exports[`Expanding property values should expand transition correctly 2`] = `
+Object {
+  "transitionDelay": "0s",
+  "transitionDuration": "2s",
+  "transitionProperty": "margin",
+  "transitionTimingFunction": "ease",
+}
+`;
+
+exports[`Expanding property values should expand transition correctly 3`] = `
+Object {
+  "transitionDelay": "1s",
+  "transitionDuration": "2s",
+  "transitionProperty": "margin",
+  "transitionTimingFunction": "ease",
+}
+`;
+
+exports[`Expanding property values should expand transition correctly 4`] = `
+Object {
+  "transitionDelay": "1s",
+  "transitionDuration": "2s",
+  "transitionProperty": "margin",
+  "transitionTimingFunction": "ease-in",
+}
+`;
+
+exports[`Expanding property values should expand transition correctly 5`] = `
+Object {
+  "transitionDelay": "0s, 0s",
+  "transitionDuration": "4s, 1s",
+  "transitionProperty": "margin-right, color",
+  "transitionTimingFunction": "ease, ease",
+}
+`;

--- a/src/__tests__/__snapshots__/expandProperty-test.js.snap
+++ b/src/__tests__/__snapshots__/expandProperty-test.js.snap
@@ -1,5 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Expanding property values should expand {padding/margin}-{inline/block} correctly 1`] = `
+Object {
+  "paddingInlineEnd": "20px",
+  "paddingInlineStart": "10px",
+}
+`;
+
+exports[`Expanding property values should expand {padding/margin}-{inline/block} correctly 2`] = `
+Object {
+  "paddingInlineEnd": "10px",
+  "paddingInlineStart": "10px",
+}
+`;
+
+exports[`Expanding property values should expand {padding/margin}-{inline/block} correctly 3`] = `
+Object {
+  "paddingBlockEnd": "20px",
+  "paddingBlockStart": "10px",
+}
+`;
+
+exports[`Expanding property values should expand {padding/margin}-{inline/block} correctly 4`] = `
+Object {
+  "paddingBlockEnd": "10px",
+  "paddingBlockStart": "10px",
+}
+`;
+
+exports[`Expanding property values should expand {padding/margin}-{inline/block} correctly 5`] = `
+Object {
+  "marginInlineEnd": "20px",
+  "marginInlineStart": "10px",
+}
+`;
+
+exports[`Expanding property values should expand {padding/margin}-{inline/block} correctly 6`] = `
+Object {
+  "marginInlineEnd": "10px",
+  "marginInlineStart": "10px",
+}
+`;
+
+exports[`Expanding property values should expand {padding/margin}-{inline/block} correctly 7`] = `
+Object {
+  "marginBlockEnd": "20px",
+  "marginBlockStart": "10px",
+}
+`;
+
+exports[`Expanding property values should expand {padding/margin}-{inline/block} correctly 8`] = `
+Object {
+  "marginBlockEnd": "10px",
+  "marginBlockStart": "10px",
+}
+`;
+
 exports[`Expanding property values should expand border-radius correctly 1`] = `
 Object {
   "borderBottomLeftRadius": "1px",

--- a/src/__tests__/__snapshots__/expandProperty-test.js.snap
+++ b/src/__tests__/__snapshots__/expandProperty-test.js.snap
@@ -600,6 +600,20 @@ Object {
 }
 `;
 
+exports[`Expanding property values should expand placeSelf correctly 1`] = `
+Object {
+  "alignItems": "start",
+  "justifyItems": "start",
+}
+`;
+
+exports[`Expanding property values should expand placeSelf correctly 2`] = `
+Object {
+  "alignItems": "end",
+  "justifyItems": "start",
+}
+`;
+
 exports[`Expanding property values should expand text-decoration correctly 1`] = `
 Object {
   "textDecorationLine": "none",

--- a/src/__tests__/__snapshots__/expandProperty-test.js.snap
+++ b/src/__tests__/__snapshots__/expandProperty-test.js.snap
@@ -655,6 +655,24 @@ Object {
 }
 `;
 
+exports[`Expanding property values should expand padding/margin correctly 12`] = `
+Object {
+  "scrollMarginBottom": "5px",
+  "scrollMarginLeft": "10px",
+  "scrollMarginRight": "20px",
+  "scrollMarginTop": "15px",
+}
+`;
+
+exports[`Expanding property values should expand padding/margin correctly 13`] = `
+Object {
+  "scrollPaddingBottom": "5px",
+  "scrollPaddingLeft": "10px",
+  "scrollPaddingRight": "20px",
+  "scrollPaddingTop": "15px",
+}
+`;
+
 exports[`Expanding property values should expand placeContent correctly 1`] = `
 Object {
   "alignContent": "center",

--- a/src/__tests__/expandProperty-test.js
+++ b/src/__tests__/expandProperty-test.js
@@ -125,7 +125,7 @@ describe('Expanding property values', () => {
     expect(expandProperty('textDecoration', 'underline')).toMatchSnapshot()
     expect(expandProperty('textDecoration', 'navy dotted underline')).toMatchSnapshot()
   })
-  
+
   it('should expand overflow correctly', () => {
     expect(expandProperty('overflow', 'visible')).toMatchSnapshot()
     expect(expandProperty('overflow', 'scroll hidden')).toMatchSnapshot()
@@ -136,5 +136,18 @@ describe('Expanding property values', () => {
     expect(expandProperty('gap', '50%')).toMatchSnapshot()
     expect(expandProperty('gap', '20px 10px')).toMatchSnapshot()
     expect(expandProperty('gap', 'unset')).toMatchSnapshot()
+  })
+
+  it('should expand flexFlow correctly', () => {
+    expect(expandProperty('flexFlow', 'column')).toMatchSnapshot()
+    expect(expandProperty('flexFlow', 'wrap')).toMatchSnapshot()
+    expect(expandProperty('flexFlow', 'row wrap')).toMatchSnapshot()
+    expect(expandProperty('flexFlow', 'wrap row')).toMatchSnapshot()
+    // should ignore invalid value
+    expect(expandProperty('flexFlow', 'asdfg')).toMatchSnapshot()
+    expect(expandProperty('flexFlow', 'flow asdfg')).toMatchSnapshot()
+    expect(expandProperty('flexFlow', 'asdfg flow')).toMatchSnapshot()
+    expect(expandProperty('flexFlow', 'flow flow')).toMatchSnapshot()
+    expect(expandProperty('flexFlow', 'wrap wrap')).toMatchSnapshot()
   })
 })

--- a/src/__tests__/expandProperty-test.js
+++ b/src/__tests__/expandProperty-test.js
@@ -164,4 +164,9 @@ describe('Expanding property values', () => {
     expect(expandProperty('placeItems', 'center')).toMatchSnapshot()
     expect(expandProperty('placeItems', 'auto center')).toMatchSnapshot()
   })
+
+  it('should expand placeSelf correctly', () => {
+    expect(expandProperty('placeItems', 'start')).toMatchSnapshot()
+    expect(expandProperty('placeItems', 'end start')).toMatchSnapshot()
+  })
 })

--- a/src/__tests__/expandProperty-test.js
+++ b/src/__tests__/expandProperty-test.js
@@ -190,4 +190,18 @@ describe('Expanding property values', () => {
     expect(expandProperty('inset', '12px 24px 48px')).toMatchSnapshot()
     expect(expandProperty('inset', '12px 24px 48px 72px')).toMatchSnapshot()
   })
+
+  it('should expand {padding/margin}-{inline/block} correctly', () => {
+    expect(expandProperty('paddingInline', '10px 20px')).toMatchSnapshot()
+    expect(expandProperty('paddingInline', '10px')).toMatchSnapshot()
+
+    expect(expandProperty('paddingBlock', '10px 20px')).toMatchSnapshot()
+    expect(expandProperty('paddingBlock', '10px')).toMatchSnapshot()
+
+    expect(expandProperty('marginInline', '10px 20px')).toMatchSnapshot()
+    expect(expandProperty('marginInline', '10px')).toMatchSnapshot()
+
+    expect(expandProperty('marginBlock', '10px 20px')).toMatchSnapshot()
+    expect(expandProperty('marginBlock', '10px')).toMatchSnapshot()
+  })
 })

--- a/src/__tests__/expandProperty-test.js
+++ b/src/__tests__/expandProperty-test.js
@@ -150,4 +150,13 @@ describe('Expanding property values', () => {
     expect(expandProperty('flexFlow', 'flow flow')).toMatchSnapshot()
     expect(expandProperty('flexFlow', 'wrap wrap')).toMatchSnapshot()
   })
+
+  it('should expand placeContent correctly', () => {
+    expect(expandProperty('placeContent', 'center')).toMatchSnapshot()
+    expect(expandProperty('placeContent', 'center start')).toMatchSnapshot()
+
+    expect(expandProperty('placeContent', 'baseline')).toMatchSnapshot()
+    // should use "start" for base-position single value
+    expect(expandProperty('placeContent', 'left')).toMatchSnapshot()
+  })
 })

--- a/src/__tests__/expandProperty-test.js
+++ b/src/__tests__/expandProperty-test.js
@@ -159,4 +159,9 @@ describe('Expanding property values', () => {
     // should use "start" for base-position single value
     expect(expandProperty('placeContent', 'left')).toMatchSnapshot()
   })
+
+  it('should expand placeItems correctly', () => {
+    expect(expandProperty('placeItems', 'center')).toMatchSnapshot()
+    expect(expandProperty('placeItems', 'auto center')).toMatchSnapshot()
+  })
 })

--- a/src/__tests__/expandProperty-test.js
+++ b/src/__tests__/expandProperty-test.js
@@ -124,6 +124,12 @@ describe('Expanding property values', () => {
     expect(expandProperty('textDecoration', 'none')).toMatchSnapshot()
     expect(expandProperty('textDecoration', 'underline')).toMatchSnapshot()
     expect(expandProperty('textDecoration', 'navy dotted underline')).toMatchSnapshot()
+    expect(expandProperty('textDecoration', 'underline overline')).toMatchSnapshot()
+    expect(expandProperty('textDecoration', 'underline red')).toMatchSnapshot()
+    expect(expandProperty('textDecoration', 'underline wavy red')).toMatchSnapshot()
+
+    // should ignore repeated line value (invalid)
+    expect(expandProperty('textDecoration', 'underline underline')).toMatchSnapshot()
   })
 
   it('should expand overflow correctly', () => {

--- a/src/__tests__/expandProperty-test.js
+++ b/src/__tests__/expandProperty-test.js
@@ -183,4 +183,11 @@ describe('Expanding property values', () => {
     expect(expandProperty('transition', 'margin 2s 1s ease-in')).toMatchSnapshot()
     expect(expandProperty('transition', 'margin-right 4s, color 1s')).toMatchSnapshot()
   })
+
+  it('should expand inset correctly', () => {
+    expect(expandProperty('inset', '12px')).toMatchSnapshot()
+    expect(expandProperty('inset', '12px 24px')).toMatchSnapshot()
+    expect(expandProperty('inset', '12px 24px 48px')).toMatchSnapshot()
+    expect(expandProperty('inset', '12px 24px 48px 72px')).toMatchSnapshot()
+  })
 })

--- a/src/__tests__/expandProperty-test.js
+++ b/src/__tests__/expandProperty-test.js
@@ -27,6 +27,8 @@ describe('Expanding property values', () => {
         '15px calc(1em * (2 * var(--foo))) 5px calc(10px + (var(--bar) +      4em     ))'
       )
     ).toMatchSnapshot()
+    expect(expandProperty('scrollMargin', '15px 20px 5px 10px')).toMatchSnapshot()
+    expect(expandProperty('scrollPadding', '15px 20px 5px 10px')).toMatchSnapshot()
   })
 
   it('should expand flex correctly', () => {

--- a/src/__tests__/expandProperty-test.js
+++ b/src/__tests__/expandProperty-test.js
@@ -175,4 +175,12 @@ describe('Expanding property values', () => {
     expect(expandProperty('placeItems', 'start')).toMatchSnapshot()
     expect(expandProperty('placeItems', 'end start')).toMatchSnapshot()
   })
+
+  it('should expand transition correctly', () => {
+    expect(expandProperty('transition', 'initial')).toMatchSnapshot()
+    expect(expandProperty('transition', 'margin 2s')).toMatchSnapshot()
+    expect(expandProperty('transition', 'margin 2s 1s')).toMatchSnapshot()
+    expect(expandProperty('transition', 'margin 2s 1s ease-in')).toMatchSnapshot()
+    expect(expandProperty('transition', 'margin-right 4s, color 1s')).toMatchSnapshot()
+  })
 })

--- a/src/expandProperty.js
+++ b/src/expandProperty.js
@@ -173,12 +173,11 @@ function parseFlex(value) {
   if (values.length === 1) {
     // One-value syntax
     const val = values[0]
-    if (
-      val.match(PURE_NUMBER) !== null
-    ) {
+    if (PURE_NUMBER.test(val)) {
+      // flex value
       values = splitShorthand(val + ' 1 0');
     } else {
-      // It is a width value
+      // It is a width value (flex-basis)
       values = splitShorthand('1 1 ' + val);
     }
   }
@@ -226,15 +225,14 @@ function parseFlex(value) {
 
 function parseOverflow(value) {
   // https://www.w3.org/TR/css-overflow-3/#overflow-properties
-  const values = splitShorthand(value)
-
   // The overflow property is a shorthand property that sets the specified values of overflow-x
   // and overflow-y in that order. If the second value is omitted, it is copied from the first.
-  if (values.length === 1) {
-    return { overflowX: values[0], overflowY: values[0] }
-  }
+  const [overflowX, overflowY = overflowX] = splitShorthand(value)
 
-  return { overflowX: values[0], overflowY: values[1] }
+  return {
+    overflowX,
+    overflowY
+  }
 }
 
 function parseGap(value) {

--- a/src/expandProperty.js
+++ b/src/expandProperty.js
@@ -321,6 +321,16 @@ function parsePlaceContent(value) {
   }
 }
 
+// https://w3c.github.io/csswg-drafts/css-align/#place-items-property
+function parsePlaceItems(value) {
+  // This shorthand property sets both the align-items and justify-items properties in a single declaration. The first value is assigned to align-items. The second value is assigned to justify-items; if omitted, it is copied from the first value.
+  const [alignItems, justifyItems = alignItems] = splitShorthand(value);
+  return {
+    alignItems,
+    justifyItems
+  }
+}
+
 function expandProperty(property, value) {
   // special expansion for the border property as its 2 levels deep
   if (property === 'border') {
@@ -342,7 +352,6 @@ function expandProperty(property, value) {
     return parseBorderRadius(value.toString())
   }
 
-
   if (property === 'textDecoration') {
     return parseTextDecoration(value.toString())
   }
@@ -361,6 +370,10 @@ function expandProperty(property, value) {
 
   if (property === 'placeContent') {
     return parsePlaceContent(value.toString())
+  }
+
+  if (property === 'placeItems') {
+    return parsePlaceItems(value.toString())
   }
 
   if (circularExpand[property]) {

--- a/src/expandProperty.js
+++ b/src/expandProperty.js
@@ -68,7 +68,7 @@ function parseCircular(value, resolve) {
   }
 }
 
-function parsePosition(value, resolve) {
+function parseFlowRelativePosition(value, resolve) {
   const [Start, End = Start] = splitShorthand(value)
 
   return {
@@ -183,7 +183,7 @@ const borderExpand = {
   outline: key => 'outline' + key,
 }
 
-const positionExpand = {
+const flowRelativePositionExpand = {
   paddingInline: key => 'paddingInline' + key,
   paddingBlock: key => 'paddingBlock' + key,
   marginInline: key => 'marginInline' + key,
@@ -542,8 +542,8 @@ function expandProperty(property, value) {
     return parseBorder(value.toString(), borderExpand[property])
   }
 
-  if (positionExpand[property]) {
-    return parsePosition(value.toString(), positionExpand[property])
+  if (flowRelativePositionExpand[property]) {
+    return parseFlowRelativePosition(value.toString(), flowRelativePositionExpand[property])
   }
 }
 

--- a/src/expandProperty.js
+++ b/src/expandProperty.js
@@ -68,6 +68,15 @@ function parseCircular(value, resolve) {
   }
 }
 
+function parsePosition(value, resolve) {
+  const [Start, End = Start] = splitShorthand(value)
+
+  return {
+    [resolve('Start')]: Start,
+    [resolve('End')]: End,
+  }
+}
+
 function groupBy(values, divider) {
   const groups = [[]];
 
@@ -156,7 +165,7 @@ function parseTextDecoration(value) {
   }
 }
 
-var circularExpand = {
+const circularExpand = {
   borderWidth: key => 'border' + key + 'Width',
   borderColor: key => 'border' + key + 'Color',
   borderStyle: key => 'border' + key + 'Style',
@@ -164,12 +173,19 @@ var circularExpand = {
   margin: key => 'margin' + key,
 }
 
-var borderExpand = {
+const borderExpand = {
   borderLeft: key => 'borderLeft' + key,
   borderTop: key => 'borderTop' + key,
   borderRight: key => 'borderRight' + key,
   borderBottom: key => 'borderBottom' + key,
   outline: key => 'outline' + key,
+}
+
+const positionExpand = {
+  paddingInline: key => 'paddingInline' + key,
+  paddingBlock: key => 'paddingBlock' + key,
+  marginInline: key => 'marginInline' + key,
+  marginBlock: key => 'marginBlock' + key,
 }
 
 function parseFlex(value) {
@@ -522,6 +538,10 @@ function expandProperty(property, value) {
 
   if (borderExpand[property]) {
     return parseBorder(value.toString(), borderExpand[property])
+  }
+
+  if (positionExpand[property]) {
+    return parsePosition(value.toString(), positionExpand[property])
   }
 }
 

--- a/src/expandProperty.js
+++ b/src/expandProperty.js
@@ -331,6 +331,15 @@ function parsePlaceItems(value) {
   }
 }
 
+function parsePlaceSelf(value) {
+  // https://w3c.github.io/csswg-drafts/css-align/#place-self-property
+  const [alignSelf, justifySelf = alignSelf] = splitShorthand(value);
+  return {
+    alignSelf,
+    justifySelf
+  }
+}
+
 function expandProperty(property, value) {
   // special expansion for the border property as its 2 levels deep
   if (property === 'border') {
@@ -374,6 +383,10 @@ function expandProperty(property, value) {
 
   if (property === 'placeItems') {
     return parsePlaceItems(value.toString())
+  }
+
+  if (property === 'placeSelf') {
+    return parsePlaceSelf(value.toString())
   }
 
   if (circularExpand[property]) {

--- a/src/expandProperty.js
+++ b/src/expandProperty.js
@@ -245,8 +245,8 @@ function parseGap(value) {
   }
 }
 
-const flexDirectionValues = new Set([...GLOBAL_VALUES, 'row', 'row-reverse', 'column', 'column-reverse'])
-const flexWrapValues = new Set([...GLOBAL_VALUES, 'nowrap', 'wrap', 'reverse'])
+const flexDirectionValues = new Set(GLOBAL_VALUES.concat(['row', 'row-reverse', 'column', 'column-reverse']))
+const flexWrapValues = new Set(GLOBAL_VALUES.concat(['nowrap', 'wrap', 'reverse']))
 
 function parseFlexFlow(value) {
   // https://w3c.github.io/csswg-drafts/css-flexbox/#flex-flow-property

--- a/src/expandProperty.js
+++ b/src/expandProperty.js
@@ -171,6 +171,8 @@ const circularExpand = {
   borderStyle: key => 'border' + key + 'Style',
   padding: key => 'padding' + key,
   margin: key => 'margin' + key,
+  scrollPadding: key => 'scrollPadding' + key,
+  scrollMargin: key => 'scrollMargin' + key,
 }
 
 const borderExpand = {

--- a/src/expandProperty.js
+++ b/src/expandProperty.js
@@ -290,6 +290,37 @@ function parseFlexFlow(value) {
   }
 }
 
+// https://w3c.github.io/csswg-drafts/css-align/#place-content
+function parsePlaceContent(value) {
+  // The first value is assigned to align-content.
+  // The second value is assigned to justify-content
+  let [alignContent, justifyContent] = splitShorthand(value)
+  if (!justifyContent && alignContent) {
+    // if omitted, ...
+    if (
+      alignContent === 'left'
+      || alignContent === 'right'
+      || alignContent === 'first'
+      || alignContent === 'last'
+    ) {
+      // invalid value, ignore both values
+      return {}
+    }
+    if (alignContent === 'baseline') {
+      // ..., unless that value is a <baseline-position> in which case it is defaulted to start.
+      justifyContent = 'start'
+    } else {
+      // ..., it is copied from the first value
+      justifyContent = alignContent
+    }
+  }
+
+  return {
+    alignContent,
+    justifyContent
+  }
+}
+
 function expandProperty(property, value) {
   // special expansion for the border property as its 2 levels deep
   if (property === 'border') {
@@ -326,6 +357,10 @@ function expandProperty(property, value) {
 
   if (property === 'flexFlow') {
     return parseFlexFlow(value.toString())
+  }
+
+  if (property === 'placeContent') {
+    return parsePlaceContent(value.toString())
   }
 
   if (circularExpand[property]) {

--- a/src/expandProperty.js
+++ b/src/expandProperty.js
@@ -449,6 +449,16 @@ function parseTransition(value) {
   );
 }
 
+function parseInset(value) {
+  const [top, right = top, bottom = top, left = right] = splitShorthand(value);
+  return {
+    top,
+    right,
+    bottom,
+    left,
+  };
+}
+
 function expandProperty(property, value) {
   // special expansion for the border property as its 2 levels deep
   if (property === 'border') {
@@ -500,6 +510,10 @@ function expandProperty(property, value) {
 
   if (property === 'transition') {
     return parseTransition(value.toString())
+  }
+
+  if (property === 'inset') {
+    return parseInset(value.toString())
   }
 
   if (circularExpand[property]) {


### PR DESCRIPTION
The PR does the following things:

- Add support for some flex-related properties:
  - `flex-flow`
  - `place-content`
  - `place-items`
  - `place-self`
- Add support for some circular properties:
  - `scroll-{padding/margin}`
- Add support for some position properties:
  - `{padding/margin}-{inline/block}`
- Add support for some other properties:
  - `inset`
  - `transition` (This closes #1)
- Adding unit test cases for all properties above
- Simplify the handing for `overflow`
- Fix `text-decoration` and update the snapshot
